### PR TITLE
Fix store_apertures() in Gerber.py

### DIFF
--- a/gerber_renderer/Gerber.py
+++ b/gerber_renderer/Gerber.py
@@ -633,7 +633,7 @@ class Board:
                     'X', index)+1: file.find('X', file.find(
                         'X', index)+1)]) * self.scale))
                 profile.append(str(float(file[file.find(
-                    'X', index)+1: file.find('*', index)]) * self.scale))
+                    'X', file.find('X', index)+1)+1: file.find('*', index)]) * self.scale))
             self.apertures[a_id] = (profile)
             index = file.find('ADD', index+1)
         if(a_id):


### PR DESCRIPTION
Logic error for 3 dimensional extractor for store_apertures().

The offending lines that revealed the error:
```
%ADD25P,3.436588X8X22.500000*%
%ADD26P,3.409096X8X22.500000*%
```
This is first half of the file I encountered the error (2 last lines) in (for tests etc). Exported from Eagle.
```
G04 EAGLE Gerber RS-274X export*
G75*
%MOMM*%
%FSLAX34Y34*%
%LPD*%
%INTop Copper*%
%IPPOS*%
%AMOC8*
5,1,8,0,0,1.08239X$1,22.5*%
G01*
%ADD10C,0.177800*%
%ADD11C,0.101600*%
%ADD12R,0.623600X0.723600*%
%ADD13R,0.773600X1.023600*%
%ADD14R,0.723600X0.623600*%
%ADD15R,0.611800X0.611800*%
%ADD16R,0.835400X0.177800*%
%ADD17R,0.177800X0.835400*%
%ADD18R,4.600000X4.600000*%
%ADD19C,1.000000*%
%ADD20R,1.036800X0.936800*%
%ADD21R,1.800000X1.000000*%
%ADD22R,1.800000X1.100000*%
%ADD23C,1.000000*%
%ADD24C,0.800000*%
%ADD25P,3.436588X8X22.500000*%
%ADD26P,3.409096X8X22.500000*%
```